### PR TITLE
[Fix] On death animation bug (modules/death/client.lua)

### DIFF
--- a/modules/death/client.lua
+++ b/modules/death/client.lua
@@ -185,7 +185,7 @@ local function initPlayerDeath(logged_dead)
 
     CreateThread(function()
         while player.isDead do
-            local sleep = 1500
+            local sleep = 500
 
             if not player.gettingRevived and not player.respawning then
                 sleep = 0


### PR DESCRIPTION
Potential fix to an exploit when bugging the death animation when dead.

Reproducing steps:

- Staying with dead animation.
- Someone hits you and you stop being with the dead animation like 1 second.
- In this moment you can spam left click and hit or shoot if you have weapon in your inventory.

Since i configured it with this little tweak it's not happening anymore.

Great work with the script, i love it.

I hope it helps!